### PR TITLE
Added card offset attribute to allow additional card positioning... 

### DIFF
--- a/example/src/main/res/layout/activity_my.xml
+++ b/example/src/main/res/layout/activity_my.xml
@@ -9,6 +9,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:rotation_degrees="15.5"
+        app:card_offset_left="0dp"
+        app:card_offset_top="0dp"
         tools:context=".MyActivity" />
 
     <include layout="@layout/buttons" />

--- a/library/src/main/java/com/lorentzos/flingswipe/SwipeFlingAdapterView.java
+++ b/library/src/main/java/com/lorentzos/flingswipe/SwipeFlingAdapterView.java
@@ -25,6 +25,8 @@ public class SwipeFlingAdapterView extends BaseFlingAdapterView {
     private int MAX_VISIBLE = 4;
     private int MIN_ADAPTER_STACK = 6;
     private float ROTATION_DEGREES = 15.f;
+    private float CARD_OFFSET_TOP = 0.0f;
+    private float CARD_OFFSET_LEFT = 0.0f;
 
     private Adapter mAdapter;
     private int LAST_OBJECT_IN_STACK = 0;
@@ -52,6 +54,8 @@ public class SwipeFlingAdapterView extends BaseFlingAdapterView {
         MAX_VISIBLE = a.getInt(R.styleable.SwipeFlingAdapterView_max_visible, MAX_VISIBLE);
         MIN_ADAPTER_STACK = a.getInt(R.styleable.SwipeFlingAdapterView_min_adapter_stack, MIN_ADAPTER_STACK);
         ROTATION_DEGREES = a.getFloat(R.styleable.SwipeFlingAdapterView_rotation_degrees, ROTATION_DEGREES);
+        CARD_OFFSET_LEFT = a.getDimension(R.styleable.SwipeFlingAdapterView_card_offset_left, CARD_OFFSET_LEFT);
+        CARD_OFFSET_TOP = a.getDimension(R.styleable.SwipeFlingAdapterView_card_offset_top, CARD_OFFSET_TOP);
         a.recycle();
     }
 
@@ -198,6 +202,9 @@ public class SwipeFlingAdapterView extends BaseFlingAdapterView {
                 childTop = getPaddingTop() + lp.topMargin;
                 break;
         }
+
+        childTop += CARD_OFFSET_TOP;
+        childLeft += CARD_OFFSET_LEFT;
 
         child.layout(childLeft, childTop, childLeft + w, childTop + h);
     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -6,6 +6,8 @@
         <attr name="rotation_degrees" format="float"/>
         <attr name="min_adapter_stack" format="integer"/>
         <attr name="max_visible" format="integer"/>
+        <attr name="card_offset_top" format="dimension"/>
+        <attr name="card_offset_left" format="dimension"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
... without altering card layout. This is useful when the SwipeFlingAdapterView must fill the screen and cover other views and we want to alter the position of the cards. Currently, adding padding to the SwipeFlingAdapterView means that some of the card will be invisible once it reaches the padding region.
