### PR TITLE
Handle null layout params.

### DIFF
--- a/library/src/main/java/com/lorentzos/flingswipe/SwipeFlingAdapterView.java
+++ b/library/src/main/java/com/lorentzos/flingswipe/SwipeFlingAdapterView.java
@@ -141,6 +141,11 @@ public class SwipeFlingAdapterView extends BaseFlingAdapterView {
     private void makeAndAddView(View child) {
 
         FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) child.getLayoutParams();
+        
+        if (lp == null) {
+            lp = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);   
+        }
+        
         addViewInLayout(child, 0, lp, true);
 
         final boolean needToMeasure = child.isLayoutRequested();


### PR DESCRIPTION
The child view may have been created in a custom adapter without assigning layout params to it. In this case the app will crash with a runtime exception:

java.lang.NullPointerException: Attempt to read from field 'int android.view.ViewGroup$MarginLayoutParams.leftMargin' on a null object reference

At line 153 of my fork when `childWidthSpec` is defined.

I think this patch is preferable to a crash scenario.